### PR TITLE
Fix awakened icon toggle making all members woke

### DIFF
--- a/TCC.Core/Controls/PartyMember.xaml.cs
+++ b/TCC.Core/Controls/PartyMember.xaml.cs
@@ -35,8 +35,10 @@ namespace TCC.Controls
 
         private void SetAwakenIcon()
         {
-            Dispatcher.Invoke(() =>
-                AwakenIcon.Visibility = SettingsManager.ShowAwakenIcon ? Visibility.Visible : Visibility.Collapsed);
+            Dispatcher.Invoke(() => {
+                if (!(DataContext is User user)) return;
+                AwakenIcon.Visibility = SettingsManager.ShowAwakenIcon ? (user.Awakened ? Visibility.Visible : Visibility.Collapsed) : Visibility.Collapsed;
+            });
         }
 
         private void SetLaurels()

--- a/TCC.Core/Controls/RaidMember.xaml.cs
+++ b/TCC.Core/Controls/RaidMember.xaml.cs
@@ -39,8 +39,10 @@ namespace TCC.Controls
 
         private void SetAwakenIcon()
         {
-            Dispatcher.Invoke(() =>
-                AwakenIcon.Visibility = SettingsManager.ShowAwakenIcon ? Visibility.Visible : Visibility.Collapsed);
+            Dispatcher.Invoke(() => {
+                if (!(DataContext is User user)) return;
+                AwakenIcon.Visibility = SettingsManager.ShowAwakenIcon ? (user.Awakened ? Visibility.Visible : Visibility.Collapsed) : Visibility.Collapsed;
+            });
         }
 
         private void SetLaurels()


### PR DESCRIPTION
The toggle option for showing the awakened icon does toggle visibility but adds awakened icons to everyone, as the data binding seems to be applied lazily. This should cause the toggle to only show the icon if the user is actually awakened. Tested and seems to work.