### PR TITLE
POST webhook using UTF-8

### DIFF
--- a/TCC.Core/TimeManager.cs
+++ b/TCC.Core/TimeManager.cs
@@ -233,6 +233,7 @@ namespace TCC
 
                     using (var client = new WebClient())
                     {
+                        client.Encoding = Encoding.UTF8;
                         client.Headers.Add(HttpRequestHeader.UserAgent, "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36");
                         client.Headers.Add(HttpRequestHeader.ContentType, "application/json");
 


### PR DESCRIPTION
Current TCC's webhook POST function causes text garbling with Japanese (also other lang too?).
This commit forces WebClient to use UTF-8 to avoid text garbling.

![tcc-patch-1](https://user-images.githubusercontent.com/33576079/43278572-75720114-9146-11e8-8275-9a7b96074f7a.PNG)
