### PR TITLE
clarify webhook is sent using 'Send test message' button

### DIFF
--- a/TCC.Core/TimeManager.cs
+++ b/TCC.Core/TimeManager.cs
@@ -209,14 +209,16 @@ namespace TCC
             }
         }
 
-        public void SendWebhookMessageOld()
+        public void SendWebhookMessageOld(bool testMessage = false)
         {
             if (!string.IsNullOrEmpty(SettingsManager.Webhook))
             {
                 var sb = new StringBuilder("{");
                 sb.Append("\""); sb.Append("content"); sb.Append("\"");
                 sb.Append(":");
-                sb.Append("\""); sb.Append(SettingsManager.WebhookMessage); sb.Append("\"");
+                sb.Append("\""); sb.Append(SettingsManager.WebhookMessage);
+                if (testMessage) sb.Append(" (Test message)");
+                sb.Append("\"");
                 sb.Append(",");
                 sb.Append("\""); sb.Append("username"); sb.Append("\"");
                 sb.Append(":");

--- a/TCC.Core/Windows/SettingsWindow.xaml.cs
+++ b/TCC.Core/Windows/SettingsWindow.xaml.cs
@@ -72,7 +72,7 @@ namespace TCC.Windows
 
         private void SendWebhookTest(object sender, RoutedEventArgs e)
         {
-            TimeManager.Instance.SendWebhookMessageOld();
+            TimeManager.Instance.SendWebhookMessageOld(testMessage: true);
         }
 
         private void OpenSettingsFolder(object sender, RoutedEventArgs e)


### PR DESCRIPTION
When webhook POST is invoked from `Send test message` button in TCC, add string "(Test message)" to end of text.
This helps to avoid confusion of server members...

![tcc-patch-2](https://user-images.githubusercontent.com/33576079/43279017-bb87b738-9147-11e8-9218-579fbd84d0bf.PNG)
